### PR TITLE
New feats

### DIFF
--- a/core/scripting/include/bypass_guard.inc
+++ b/core/scripting/include/bypass_guard.inc
@@ -38,6 +38,7 @@ enum _:ALLOW_TYPE_ENUM {
     ALLOW_TYPE__ACCESS_FLAGS,
     ALLOW_TYPE__STEAMID_IMMUNITY,
     ALLOW_TYPE__IP_WHITELIST,
+    ALLOW_TYPE__STATS_IMMUNITY,
     ALLOW_TYPE__AS_WHITELIST,
     ALLOW_TYPE__CHECK
 }
@@ -181,10 +182,12 @@ native BypassGuard_SendProxyStatus(pPlayer, bool:IsProxy, bool:bSuccess);
  * @param pPlayer			    Player index
  * @param bAllowConnect   Allow connect (true) or deny (false, so player will be kicked soon)
  * @param szStatus              Supervising status as string
+ * @param bByWhitepass     true when player have whitepass, false otherwise
+ * @param bStrictStatus       Restriction status (strict/non-strict), always false when result is taken from whitepass cache
  *
  * @noreturn
  */
-native BypassGuard_SendSupervisingResult(pPlayer, bool:bAllowConnect, const szStatus[MAX_SV_STATUS_LEN]);
+native BypassGuard_SendSupervisingResult(pPlayer, bool:bAllowConnect, const szStatus[MAX_SV_STATUS_LEN], bool:bByWhitepass, bool:bStrictStatus);
 
 /**
  * Logs specified text to error log.


### PR DESCRIPTION
Bypass Guard:
* Added the ability to check a player on Proxy/VPN only if Supervisor has an active block,
and the player being checked does not have a whitepass (i.e. the player is recognized by the server as 'new') (idea by SKAJIbnEJIb).
* Added mode "2" to bypass_guard_check_proxy cvar
* Added arguments bByWhitepass and bStrictStatus to BypassGuard_SendSupervisingResult native
* Changed the logic order, now the request to the supervisor is sent before checking on Proxy/VPN
* Added the ability to skip checking players who, according to statistics, spent # or more minutes on the server (idea by SKAJIbnEJIb).
* Added bypass_guard_allow_by_stats cvar
* Added bypass_guard_stats_type cvar
* bypass_guard.inc: ALLOW_TYPE__STATS_IMMUNITY element added to ALLOW_TYPE_ENUM enumeration

Supervisor:
* Compatibility with new functionality of the core version 1.0.10 has been implemented
* The bByWhitepass and bStrictStatus arguments have been added to the BypassGuard_SendSupervisingResult native
* The ability to load DB connection settings from amxmodx/sql.cfg has been added, for this the value of the cvar
bg_sv_sql_host must be changed to "sql.cfg" (idea by SKAJIbnEJIb)
* Cleaning of obsolete records in tables has been added, once per server startup session (idea by SKAJIbnEJIb)
* The bg_sv_min_ban_time cvar has been added to support the new expected version of AMXBans RBS, the author
promised to release an update with a larger number of arguments in the amxbans_ban_pre() forward